### PR TITLE
Run `bundle install` in gem push workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,5 +23,8 @@ jobs:
         with:
           ruby-version: ruby
 
+      - name: Install dependencies
+        run: bundle install
+
       # Release
       - uses: rubygems/release-gem@v1


### PR DESCRIPTION
I didn't realize that the `bundler-cache` value was the only way that the setup-ruby action installs dependencies. 😬 Sorry! This fixes it while ensuring the cache is still not present.